### PR TITLE
Fix SN simulation: Compilation errors and model paths

### DIFF
--- a/simulations/supernova/include/OMSimSNParticleGenerators.hh
+++ b/simulations/supernova/include/OMSimSNParticleGenerators.hh
@@ -9,6 +9,7 @@
 #include "G4VUserPrimaryGeneratorAction.hh"
 #include "OMSimPrimaryGeneratorMessenger.hh"
 #include "OMSimSNTools.hh"
+#include "G4RandomTools.hh"
 
 #include <globals.hh>
 #include <vector>
@@ -108,7 +109,5 @@ private:
     G4double totalCrossSection(G4double energy);
 };
 
-
-#endif
 
 

--- a/simulations/supernova/src/OMSimSNTools.cc
+++ b/simulations/supernova/src/OMSimSNTools.cc
@@ -21,7 +21,7 @@
  */
 std::pair<std::string, std::string> OMSimSNTools::getFileNames(int p_value)
 {
-    const std::string basePath = "../supernova/models/";
+    const std::string basePath = "../simulations/supernova/models/";
 
     const std::map<int, std::pair<std::string, std::string>> fileMap = {
         {0, {basePath + "Flux_Nu_Heavy_ls220.cfg", basePath + "Flux_Nubar_Heavy_ls220.cfg"}}, // 27 solar masses type II model


### PR DESCRIPTION
New user had issues starting out with the Supernova simulation.
No more compile errors and first check (./OMSimSupernova -v with /run/beamOn 10) looks fine.
 